### PR TITLE
Resin nodes and structure changes

### DIFF
--- a/code/controllers/subsystem/weeds.dm
+++ b/code/controllers/subsystem/weeds.dm
@@ -24,6 +24,7 @@ SUBSYSTEM_DEF(weeds)
 		var/obj/effect/alien/weeds/node/N = currentrun[A]
 		currentrun -= A
 		var/turf/T = A
+
 		if (istype(N.loc, /turf/closed/wall/resin))
 			continue
 		

--- a/code/controllers/subsystem/weeds.dm
+++ b/code/controllers/subsystem/weeds.dm
@@ -24,7 +24,9 @@ SUBSYSTEM_DEF(weeds)
 		var/obj/effect/alien/weeds/node/N = currentrun[A]
 		currentrun -= A
 		var/turf/T = A
-
+		if (istype(N.loc, /turf/closed/wall/resin))
+			continue
+		
 		if(QDELETED(N) || QDELETED(T))
 			pending -= T
 			continue

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -533,9 +533,6 @@ GLOBAL_LIST_INIT(unweedable_areas, typecacheof(list(
 			else
 				has_obstacle = TRUE
 				break
-		if(istype(O, /obj/effect/alien/weeds/node))
-			has_obstacle = TRUE
-			break
 
 		if(O.density && !(O.flags_atom & ON_BORDER))
 			has_obstacle = TRUE


### PR DESCRIPTION
## About The Pull Request

Resin nodes will now be buildable on BUT resin nearby will NOT grow if a wall is built on them
## Why It's Good For The Game

Lets people build on top of stuff while discouraging building walls on nodes

## Changelog
:cl:
balance: Xenos may now build on top of resin nodes, but walls built on top of nodes will halt node growth
/:cl:
