### PR TITLE
lasgun heat lens max range

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1028,6 +1028,8 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 12 //requires mod with -0.15 multiplier should math out to 10
 	penetration = 0
 	flags_ammo_behavior = AMMO_ENERGY|AMMO_INCENDIARY
+	max_range = 7
+	accurate_range = 7
 
 /datum/ammo/energy/lasgun/M43/blast
 	name = "wide range laser blast"


### PR DESCRIPTION
## About The Pull Request

the fact this didn't have this at first was stupid

## Why It's Good For The Game
>>>most acccurate and easy to get form of consistent flamestacks with no area control loss
>>>>every pfc can get it
>>>>>can offscreen for some reason??

## Changelog
:cl:

balance: heat lens max range nerfed to 7 tiles

/:cl:
