### PR TITLE
Revert "Dmrbuff"

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -458,7 +458,8 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	flags_ammo_behavior = AMMO_BALLISTIC
 	accurate_range_min = 0
 	accurate_range = 30
-	damage = 60
+	damage = 55
+	scatter = -15
 	penetration = 15
 
 /datum/ammo/bullet/rifle/standard_dmr/incendiary

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -174,9 +174,9 @@
 	starting_attachment_types = list(/obj/item/attachable/stock/dmr, /obj/item/attachable/scope/mini)
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 13, "rail_y" = 18, "under_x" = 24, "under_y" = 13, "stock_x" = 14, "stock_y" = 10)
 
-	fire_delay = 0.6 SECONDS
+	fire_delay = 0.8 SECONDS
 	accuracy_mult = 1.25
-	scatter = -30
+	scatter = -15
 	burst_amount = 1
 
 


### PR DESCRIPTION
Reverts MoHBranch/MarinesOfHestia#11. By MJP
Being rebalanced entirely. The weapon outperforms immensely and obviously was not tested as heavily as it needed to be. Capable of taking out a T2, Shrike and many other xenos with as little as three shots that can be quickly fired due to a lack of removal of Quick-Burst.

- Alcoholism Incarnate